### PR TITLE
update calibration s.t. it fits description at the top of the file

### DIFF
--- a/calibration_check.py
+++ b/calibration_check.py
@@ -11,7 +11,7 @@ import numpy as np
 
 def check_calibration():
 
-    data_dir = "RawData/"
+    data_dir = sys.argv[1]
     subject_calibration_dict = {}
     for item in os.listdir(data_dir):
         if "P" in item:


### PR DESCRIPTION
the description of `calibration_check.py` reads as follows:

```python
# A really rough calibration checker
# Checks the calibration results of each participant from the .EDF files based on simple pattern matching
# usage: python calibration_check.py RawData/
```

but currently the data folder is hardcoded, see [here](https://github.com/norahollenstein/copco-processing/blob/main/calibration_check.py#L14C4-L14C4), via

```python
data_dir = "RawData/"
```

this PR resolves the difference in implementation vs. documentation, opting for the documentation and allowing you to freely choose the directory you want to check.

